### PR TITLE
Refactor if-then panic! into assert!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,20 +71,16 @@
 macro_rules! assert_lt {
     ($left:expr, $right:expr) => ({
         let (left, right) = (&($left), &($right));
-        if !(left < right) {
-            panic!("assertion failed: `(left < right)`\n  left: `{:?}`,\n right: `{:?}`",
+        assert!(left < right, "assertion failed: `(left < right)`\n  left: `{:?}`,\n right: `{:?}`",
                    left, right);
-        }
     });
     ($left:expr, $right:expr, ) => ({
         assert_lt!($left, $right);
     });
     ($left:expr, $right:expr, $($msg_args:tt)+) => ({
         let (left, right) = (&($left), &($right));
-        if !(left < right) {
-            panic!("assertion failed: `(left < right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
+        assert!(left < right, "assertion failed: `(left < right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
                    left, right, format_args!($($msg_args)+));
-        }
     })
 }
 
@@ -113,20 +109,16 @@ macro_rules! assert_lt {
 macro_rules! assert_gt {
     ($left:expr, $right:expr) => ({
         let (left, right) = (&($left), &($right));
-        if !(left > right) {
-            panic!("assertion failed: `(left > right)`\n  left: `{:?}`,\n right: `{:?}`",
+        assert!(left > right, "assertion failed: `(left > right)`\n  left: `{:?}`,\n right: `{:?}`",
                    left, right);
-        }
     });
     ($left:expr, $right:expr, ) => ({
         assert_gt!($left, $right);
     });
     ($left:expr, $right:expr, $($msg_args:tt)+) => ({
         let (left, right) = (&($left), &($right));
-        if !(left > right) {
-            panic!("assertion failed: `(left > right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
+        assert!(left > right, "assertion failed: `(left > right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
                    left, right, format_args!($($msg_args)+));
-        }
     })
 }
 
@@ -156,20 +148,16 @@ macro_rules! assert_gt {
 macro_rules! assert_le {
     ($left:expr, $right:expr) => ({
         let (left, right) = (&($left), &($right));
-        if !(left <= right) {
-            panic!("assertion failed: `(left <= right)`\n  left: `{:?}`,\n right: `{:?}`",
+        assert!(left <= right, "assertion failed: `(left <= right)`\n  left: `{:?}`,\n right: `{:?}`",
                    left, right);
-        }
     });
     ($left:expr, $right:expr, ) => ({
         assert_le!($left, $right);
     });
     ($left:expr, $right:expr, $($msg_args:tt)+) => ({
         let (left, right) = (&($left), &($right));
-        if !(left <= right) {
-            panic!("assertion failed: `(left <= right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
+        assert!(left <= right, "assertion failed: `(left <= right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
                    left, right, format_args!($($msg_args)+));
-        }
     })
 }
 
@@ -199,20 +187,16 @@ macro_rules! assert_le {
 macro_rules! assert_ge {
     ($left:expr, $right:expr) => ({
         let (left, right) = (&($left), &($right));
-        if !(left >= right) {
-            panic!("assertion failed: `(left >= right)`\n  left: `{:?}`,\n right: `{:?}`",
+        assert!(left >= right, "assertion failed: `(left >= right)`\n  left: `{:?}`,\n right: `{:?}`",
                    left, right);
-        }
     });
     ($left:expr, $right:expr, ) => ({
         assert_ge!($left, $right);
     });
     ($left:expr, $right:expr, $($msg_args:tt)+) => ({
         let (left, right) = (&($left), &($right));
-        if !(left >= right) {
-            panic!("assertion failed: `(left >= right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
+        assert!(left >= right, "assertion failed: `(left >= right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
                    left, right, format_args!($($msg_args)+));
-        }
     })
 }
 


### PR DESCRIPTION
Hi there!

Thank you so much for this incredibly useful crate! It has often made life much easier.

Today for the first time, Clippy gave me dozens of new warnings relating to an `if_then_panic` lint. Here's an example:

```
warning: only a `panic!` in `if`-then statement
   --> src\project\dsl.rs:119:29
    |
119 | ...                   debug_assert_le!(0, part_index);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_then_panic
    = note: this warning originates in the macro `assert_le` (in Nightly builds, run with -Z macro-backtrace for more info) 
```

As you can see, I have replaced the if-then-panic! pattern with assert! each time it appears.

I made sure the tests still passed, and also ran some code in release mode with problematic debug_assert_*s to make sure that they weren't triggered.

I welcome your thoughts.

Thanks again,
Iain
