### PR TITLE
Support usage in `no_std` contexts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,11 @@
 //! }
 //! ```
 
+#![no_std]
 #![deny(missing_docs)]
+
+#[cfg(test)]
+extern crate std;
 
 /// Panics if the first expression is not strictly less than the second.
 /// Requires that the values be comparable with `<`.


### PR DESCRIPTION
## Sumary
In short, this crate already is no_std compatible, it just doesn't declare no_std in the root `lib.rs`.  Adding that `no_std` declaration makes it usable in no_std projects.

## Motivation
This crate is used widely in the `wasmtime` project, among others, which currently doesn't support no_std. However, I along with others are working to port it to no_std environments, and this crate is part of the puzzle.