### PR TITLE
Switch to an outlined `#[track_caller]`-based impl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, nightly, "1.38.0"]
+        rust: [stable, nightly, "1.46.0"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docs](https://docs.rs/more-asserts/badge.svg)](https://docs.rs/more-asserts)
 [![Latest Version](https://img.shields.io/crates/v/arcstr.svg)](https://crates.io/crates/more-asserts)
-<!-- ![Minimum Rust Version](https://img.shields.io/badge/MSRV%201.38.0-blue.svg) -->
+![Minimum Rust Version](https://img.shields.io/badge/MSRV%201.46.0-blue.svg)
 
 Small library providing assertion macros similar to the `{debug_,}assert_{eq,ne}` macros in the stdlib.
 

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,0 +1,65 @@
+//! Outlined format+panic code.
+//!
+//! This reduces the code bloat caused by our macros, improving performance in
+//! the case that the assertions are not triggered.
+use core::fmt;
+
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[doc(hidden)]
+pub enum AssertType {
+    Lt,
+    Gt,
+    Le,
+    Ge,
+    // TODO: `matches`? `contains`?
+}
+
+#[cold]
+#[track_caller]
+pub(crate) fn assert_failed_nomsg_impl(
+    left: &dyn fmt::Debug,
+    right: &dyn fmt::Debug,
+    ty: AssertType,
+) -> ! {
+    assert_failed_impl(left, right, ty, None);
+}
+
+#[cold]
+#[track_caller]
+pub(crate) fn assert_failed_msg_impl(
+    left: &dyn fmt::Debug,
+    right: &dyn fmt::Debug,
+    ty: AssertType,
+    msg: fmt::Arguments<'_>,
+) -> ! {
+    assert_failed_impl(left, right, ty, Some(msg))
+}
+
+#[cold]
+#[track_caller]
+#[inline(never)]
+fn assert_failed_impl(
+    left: &dyn fmt::Debug,
+    right: &dyn fmt::Debug,
+    ty: AssertType,
+    msg: Option<fmt::Arguments<'_>>,
+) -> ! {
+    let compare = match ty {
+        AssertType::Lt => "<",
+        AssertType::Gt => ">",
+        AssertType::Le => "<=",
+        AssertType::Ge => ">=",
+    };
+    if let Some(msg) = msg {
+        panic!(
+            "assertion failed: `(left {} right)`\n  left: `{:?}`,\n right: `{:?}`: {}",
+            compare, left, right, msg,
+        );
+    } else {
+        panic!(
+            "assertion failed: `(left {} right)`\n  left: `{:?}`,\n right: `{:?}`",
+            compare, left, right,
+        );
+    }
+}


### PR DESCRIPTION
This has a consequence of raising our MSRV to 1.46.0[^1], so it will be done as part of a major version bump.

On the bright side, it should improve performance in cases where the assert does not fire, and reduce the amount of code bloat the macros cause.

It should also make #5 irrelevant, because we no longer directly invoke `panic!`.

[^1]: 1.46.0 is much newer than the previous requirement, but still not *that* new -- it's a few years old now and is available on all the major linux distros (well, it's in Debian stable, which is usually the problematic one), so I doubt it will be a problem. Feel free to let me know if I misjudged this, though.